### PR TITLE
Create build.properties file

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.11


### PR DESCRIPTION
Application is stuck at Getting org.scala-sbt sbt 0.13.11... , for bypassing that thing we need to add build.properties file.